### PR TITLE
fix: 追加初音未来缓释片的伤害减免信息显示

### DIFF
--- a/Config/items.xml
+++ b/Config/items.xml
@@ -177,6 +177,8 @@
 				<display_value name="dStopsConcussion" value="1"/>
 				<!-- 抗眩晕效果显示 -->
 				<display_value name="dStunResist" value="1"/>
+				<!-- 减伤提示 -->
+				<display_value name="dHealthLoss" value=".39"/>
 				<!-- 体力上限增加39 -->
 				<triggered_effect trigger="onSelfPrimaryActionEnd" action="ModifyCVar" cvar=".foodStaminaBonusAdd" operation="add" value="39"/>
 				<!-- 添加持续效果buff -->

--- a/Config/ui_display.xml
+++ b/Config/ui_display.xml
@@ -14,6 +14,7 @@
 		</item_display_info>
 
 		<item_display_info display_type="drugHatsuneMiku" display_group="groupConsumables">
+			<display_entry name="dHealthLoss" title_key="statHealthLoss" display_type="Percent" display_leading_plus="true"/>
 			<display_entry name="dInstantHealth" title_key="statHealthAmount"/>
 			<display_entry name="$waterAmountAdd" title_key="statWaterAmount"/>
 			<display_entry name="dStopsConcussion" title_key="statStopsConcussion" display_type="Percent"/>


### PR DESCRIPTION
追加显示

<img width="1611" height="1028" alt="image" src="https://github.com/user-attachments/assets/a106729c-8d1d-40b9-bcb9-cbf1d706e900" />
